### PR TITLE
Add environment variable support to override images being used

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,2 @@
+WEB_IMAGE_TAG=rolling
+WANDA_IMAGE_TAG=rolling

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 /data/catalog/*
 /data/facts-gathering/*
+
+/.env

--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ Hang tight and wait until everything is ready...
 
 When ready browse to http://localhost:4000 and log in with the following credentials: user `admin`, password `adminpassword`
 
+### Environment variables
+
+It is possible to customize the playground by setting environment variables.
+
+Copy the `.env.dist` file to `.env` and edit it as per the specific needs.
+
+```bash
+$ cp .env.dist .env
+```
+
+See [.env.dist](./.env.dist) for a list of available variables.
+
+#### Changing the images tags
+
+By default `demo` images are used for weba nd wanda containers.
+Edit the `.env` file to use a different tag.
+
+```bash
+WEB_IMAGE_TAG=2.1.0 # a specific release tag
+WANDA_IMAGE_TAG=1790-env # a PR branch tag ${PR_NUMBER}-env
+```
+
 ### Loading photofinish scenarios
 
 Scenarios are loaded with [photofinish](https://github.com/trento-project/photofinish). 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   trento-web:
-    image: ghcr.io/trento-project/trento-web:demo
+    image: ghcr.io/trento-project/trento-web:${WEB_IMAGE_TAG:-demo}
     pull_policy: always
     environment:
       DATABASE_URL: ecto://dbUser:dbPassword@postgres/trento_web
@@ -47,7 +47,7 @@ services:
     entrypoint: ["/bin/sh", "-c", "/app/bin/trento eval \"Trento.Release.init()\" && /app/bin/trento start"]
 
   wanda:
-    image: ghcr.io/trento-project/trento-wanda:demo
+    image: ghcr.io/trento-project/trento-wanda:${WANDA_IMAGE_TAG:-demo}
     pull_policy: always
     environment:
       DATABASE_URL: ecto://dbUser:dbPassword@postgres/wanda


### PR DESCRIPTION
This PR introduces environment variables to override playground defaults like image tags being used for web and wanda.

Here's the excerpt of the added documentation

---

### Environment variables

It is possible to customize the playground by setting environment variables.

Copy the `.env.dist` file to `.env` and edit it as per the specific needs.

```bash
$ cp .env.dist .env
```

See [.env.dist](https://github.com/trento-project/playground/blob/043b942474b939e03569cb37af830295cdce6a25/.env.dist) for a list of available variables.

#### Changing the images tags

By default `demo` images are used for weba nd wanda containers.
Edit the `.env` file to use a different tag.

```bash
WEB_IMAGE_TAG=2.1.0 # a specific release tag
WANDA_IMAGE_TAG=1790-env # a PR branch tag ${PR_NUMBER}-env
```

---