### PR TITLE
Enable alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,10 @@ After the setup, also a configuration file useful to instrument what target agen
 Any changes to the file are reflected in the running instance.
 
 Please see [Wanda demo doc](https://github.com/trento-project/wanda/blob/main/guides/development/demo.md#modify-demo-facts-configuration) for extra information about the file format.
+
+### Alerting
+
+Trento sends email when something worth to be notified happens. 
+See [Alerting](https://github.com/trento-project/web/blob/main/guides/alerting/alerting.md).
+
+A local mailserver is available at [`localhost:8025`](http://localhost:8025) to inspect sent emails.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,14 +15,13 @@ services:
       REFRESH_TOKEN_ENC_SECRET: an0th3rDummyS3cr3t
       # JWT_AUTHENTICATION_ENABLED: "false"
 
-      
-      ENABLE_ALERTING: "false"
-      # SMTP_SERVER: "{{ .Values.alerting.smtpServer }}"
-      # SMTP_PORT: "{{ .Values.alerting.smtpPort }}"
-      # SMTP_USER: "{{ .Values.alerting.smtpUser }}"
-      # SMTP_PASSWORD: "{{ .Values.alerting.smtpPassword }}"
-      # ALERT_SENDER: "{{ .Values.alerting.sender }}"
-      # ALERT_RECIPIENT: "{{ .Values.alerting.recipient }}"
+      ENABLE_ALERTING: "true"
+      SMTP_SERVER: mailserver
+      SMTP_PORT: 1025
+      SMTP_USER: ""
+      SMTP_PASSWORD: ""
+      ALERT_SENDER: "no-reply@trento-playground.com"
+      ALERT_RECIPIENT: "play@trento-playground.com"
 
       GRAFANA_PUBLIC_URL: http://localhost:3000
       GRAFANA_API_URL: http://grafana:3000/api
@@ -35,6 +34,7 @@ services:
       - postgres
       - rabbitmq
       - grafana
+      - mailserver
     ports:
       - 4000:4000
     # healthcheck:
@@ -102,6 +102,13 @@ services:
       GF_AUTH_ANONYMOUS_ENABLED: "true"
     ports:
       - 3000:3000
+  
+  mailserver:
+    image: mailhog/mailhog:v1.0.1
+    pull_policy: always
+    ports:
+      - 1025:1025
+      - 8025:8025
 
 volumes:
   pg_data:


### PR DESCRIPTION
This PR enables alerting for the playground instance and adds a local mailhog server to inspect outgoing notifications.

Emails can be inspected at http://localhost:8025

![image](https://github.com/trento-project/playground/assets/8167114/d8586858-27f9-4b5b-87a4-89dd1db79b51)
