### PR TITLE
Clone repos via https

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,13 @@ help:
 
 init-web:
 	if [ ! -d ".tmp/web" ]; then \
-		git clone git@github.com:trento-project/web.git .tmp/web; \
-    fi
+		git clone https://github.com/trento-project/web.git .tmp/web; \
+	fi
 
 init-wanda:
 	if [ ! -d ".tmp/wanda" ]; then \
-		git clone git@github.com:trento-project/wanda.git .tmp/wanda; \
-    fi
+		git clone https://github.com/trento-project/wanda.git .tmp/wanda; \
+	fi
 
 clean-web:
 	rm -fr .tmp/web

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ In order to leverage this playground make sure to have installed
 - `Docker`
 - `Docker Compose`
 - `make`
+- `git`
 
 ### Windows users
 Install [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/) and/or leverage [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install).


### PR DESCRIPTION
Allows to fallback cloning from github via https when ssh download is not available.